### PR TITLE
LOGGING: Added cspec definiton to include entity name to log file. Closes #26

### DIFF
--- a/src/lib/DBOD/Job.pm
+++ b/src/lib/DBOD/Job.pm
@@ -37,16 +37,28 @@ has '_result' => ( is => 'rw', isa => 'Num' );
 
 
 sub BUILD {
+    
     my $self = shift;
+    
     # Remove screen appender from logger if debug is not enabled
     unless( $self->debug ) {
         Log::Log4perl::eradicate_appender('screen');
     }
+
+    # Sets ENTITY environment variable os it can be used when loggin
+    # This is an easy hack around not being able to find the right 
+    # reference to use on the anonymous function used on the logger
+    # CSPEC
+    
+    $ENV{ENTITY} = $self->entity;
+
     # Load General Configuration from file
     $self->config(DBOD::Config::load());
+
     # Load cache file
     my %cache = load_cache($self->config);
     $self->md_cache(\%cache);
+
     # Load entity metadata
     $self->metadata(
         get_entity_metadata($self->entity, $self->md_cache, $self->config));
@@ -82,11 +94,12 @@ sub BUILD {
                       db_user => $db_user,
                       db_password => $db_password,
                       db_attrs => $db_attrs,));
-        }
-        else { 
-            $self->log->info('Skipping DB connection with instance');
-        }
-        return;
+    }
+    else { 
+        $self->log->info('Skipping DB connection with instance');
+    }
+    
+    return;
 };
 
 sub run {

--- a/src/share/logger.conf
+++ b/src/share/logger.conf
@@ -13,7 +13,8 @@ log4perl.appender.file.DatePattern = yyyy-MM-dd
 log4perl.appender.file.mode     = append
 log4perl.appender.file.umask    = 0000
 log4perl.appender.file.layout   = Log::Log4perl::Layout::PatternLayout
-log4perl.appender.file.layout.ConversionPattern = [%d] [%p] (PID:%P %F{1} %M:%L) %m%n
+log4perl.appender.file.layout.cspec.E =  sub { return $ENV{ENTITY} }
+log4perl.appender.file.layout.ConversionPattern = [%d] [%p] [%E] (PID:%P %F{1} %M:%L) %m%n
 
 log4perl.appender.syslog           = Log::Dispatch::Syslog
 log4perl.appender.syslog.min_level = debug
@@ -21,3 +22,4 @@ log4perl.appender.syslog.ident     = dbod-core
 log4perl.appender.syslog.facility  = daemon
 log4perl.appender.syslog.layout    = Log::Log4perl::Layout::PatternLayout
 log4perl.appender.syslog.layout.ConversionPattern = [%d] [%p] (PID:%P %F{1} %M:%L) %m%n
+


### PR DESCRIPTION
Set the entity as an environment variable during DBOD::Job instantiation so the value is available to use during logging.

Closes #26.
